### PR TITLE
Add self-targeted honor commands for story mode support

### DIFF
--- a/src/game/features/players/toxic/MaximumHonor.cpp
+++ b/src/game/features/players/toxic/MaximumHonor.cpp
@@ -54,6 +54,20 @@ namespace YimMenu::Features
 		}
 	};
 
+	class MaximumHonorSelf : public Command
+	{
+		using Command::Command;
+
+		virtual void OnCall() override
+		{
+			if (Self::GetPlayer().IsValid())
+			{
+				MaxHonor(1 << Self::GetPlayer().GetId());
+			}
+		}
+	};
+
 	static MaximumHonor _MaximumHonor{"maxhonor", "Max Honor", "Sets the player's honor to the maximum value", 0, false};
 	static MaximumHonorAll _MaximumHonorAll{"maxhonorall", "Give All Max Honor", "Sets all player's honor to the maximum value"};
+	static MaximumHonorSelf _MaximumHonorSelf{"maxhonorself", "Max Honor Self", "Sets your own honor to the maximum value"};
 }

--- a/src/game/features/players/toxic/MinimumHonor.cpp
+++ b/src/game/features/players/toxic/MinimumHonor.cpp
@@ -54,6 +54,20 @@ namespace YimMenu::Features
 		}
 	};
 
+	class MinimumHonorSelf : public Command
+	{
+		using Command::Command;
+
+		virtual void OnCall() override
+		{
+			if (Self::GetPlayer().IsValid())
+			{
+				MinHonor(1 << Self::GetPlayer().GetId());
+			}
+		}
+	};
+
 	static MinimumHonor _MinimumHonor{"minhonor", "Min Honor", "Sets the player's honor to the minimum value", 0, false};
 	static MinimumHonorAll _MinimumHonorAll{"minhonorall", "Give All Min Honor", "Sets all player's honor to the minimum value"};
+	static MinimumHonorSelf _MinimumHonorSelf{"minhonorself", "Min Honor Self", "Sets your own honor to the minimum value"};
 }

--- a/src/game/frontend/submenus/Self.cpp
+++ b/src/game/frontend/submenus/Self.cpp
@@ -153,6 +153,8 @@ namespace YimMenu::Submenus
 
 		toolsGroup->AddItem(std::make_shared<CommandItem>("suicide"_J));
 		toolsGroup->AddItem(std::make_shared<CommandItem>("clearcrimes"_J));
+		toolsGroup->AddItem(std::make_shared<CommandItem>("maxhonorself"_J));
+		toolsGroup->AddItem(std::make_shared<CommandItem>("minhonorself"_J));
 
 		toolsGroup->AddItem(std::make_shared<BoolCommandItem>("npcignore"_J));
 		toolsGroup->AddItem(std::make_shared<BoolCommandItem>("eagleeye"_J));


### PR DESCRIPTION
The maxhonor and minhonor commands previously only worked as PlayerCommands, requiring a player target (online mode). This caused a warning in story mode: "maxhonor requires a player argument".

Changes:
- Added MaximumHonorSelf and MinimumHonorSelf commands that target the player themselves
- These new commands work in both story mode and online mode
- Added maxhonorself and minhonorself to the Self menu UI under Tools
- Commands now properly handle both scenarios:
  - Online: Use maxhonor/minhonor to target other players
  - Story/Self: Use maxhonorself/minhonorself to modify your own honor

🤖 Generated with [Claude Code](https://claude.com/claude-code)